### PR TITLE
Add TypeScript types to utility modules

### DIFF
--- a/src/utils/boundaryTypes.ts
+++ b/src/utils/boundaryTypes.ts
@@ -1,0 +1,20 @@
+export interface Block {
+    id: string;
+    text: string;
+    [key: string]: unknown;
+}
+
+export interface BoundaryPair {
+    prevId: string;
+    currId: string;
+    prevText: string;
+    currText: string;
+}
+
+export interface BoundaryEdit {
+    prevId: string;
+    currId: string;
+    merged: string | null;
+    firstClean: string | null;
+    secondClean: string | null;
+}

--- a/src/utils/boundaryUtils.ts
+++ b/src/utils/boundaryUtils.ts
@@ -3,14 +3,16 @@
 // Pure utility functions for detecting and applying boundary edits
 // ------------------------------------------------------------
 
+import { Block, BoundaryPair, BoundaryEdit } from "./boundaryTypes.ts";
+
 /**
  * Extract boundary pairs (prev/next blocks) across chunk borders.
- * @param {Array<{id:string,text:string}>} finalBlocks
- * @param {number[]} blocksCountPerChunk
- * @returns {Array<{ prevId:string, currId:string, prevText:string, currText:string }>}
  */
-export function extractBoundaryPairsWithText(finalBlocks: any[], blocksCountPerChunk: string | any[]) {
-    const pairs = [];
+export function extractBoundaryPairsWithText(
+    finalBlocks: Block[],
+    blocksCountPerChunk: number[]
+): BoundaryPair[] {
+    const pairs: BoundaryPair[] = [];
     let offset = 0;
 
     for (let i = 0; i < blocksCountPerChunk.length - 1; i++) {
@@ -35,14 +37,11 @@ export function extractBoundaryPairsWithText(finalBlocks: any[], blocksCountPerC
 
 /**
  * Apply processed edits to finalBlocks array.
- * @param {Array<object>} blocks
- * @param {Array<object>} edits
- * @returns {Array<object>}
  */
-export function applyBoundaryEdits(blocks, edits) {
+export function applyBoundaryEdits(blocks: Block[], edits: BoundaryEdit[]): Block[] {
     if (!edits || edits.length === 0) return blocks;
 
-    const idToIndex = new Map(blocks.map((b, i) => [b.id, i]));
+    const idToIndex = new Map<string, number>(blocks.map((b, i) => [b.id, i]));
 
     [...edits].reverse().forEach(edit => {
         const iPrev = idToIndex.get(edit.prevId);

--- a/src/utils/captionParser.ts
+++ b/src/utils/captionParser.ts
@@ -1,7 +1,12 @@
 
 // utils/captionParser.js
 
-import {parseStringPromise} from 'xml2js';
+import { parseStringPromise } from 'xml2js';
+
+interface CaptionEntry {
+    start: number;
+    text: string;
+}
 
 /**
  * Парсит XML субтитров YouTube (TTML или публичный timedtext) в массив { start, text }.
@@ -12,11 +17,11 @@ import {parseStringPromise} from 'xml2js';
  * @param {string} xml - сырой XML из captions.download или public timedtext
  * @returns {Promise<Array<{start: number, text: string}>>}
  */
-export async function parseCaptionsXml(xml) {
+export async function parseCaptionsXml(xml: string): Promise<CaptionEntry[]> {
     if (!xml || !xml.trim()) {
         throw new Error('Empty XML received — no captions payload');
     }
-    const json = await parseStringPromise(xml);
+    const json: any = await parseStringPromise(xml);
     if (!json) {
         console.error('[parseCaptionsXml] parseStringPromise returned null for XML:', xml.slice(0, 200));
         throw new Error('Failed to parse XML — invalid format');
@@ -26,7 +31,7 @@ export async function parseCaptionsXml(xml) {
     console.log("json is - ", json)
     if (json.tt && json.tt.body && json.tt.body[0] && json.tt.body[0].div && json.tt.body[0].div[0]) {
         const paragraphs = json.tt.body[0].div[0].p || [];
-        return paragraphs.map(node => ({
+        return paragraphs.map((node: any): CaptionEntry => ({
             start: parseFloat(node.$.begin) || 0,
             text: (node._ || '')
                 .trim()
@@ -37,7 +42,7 @@ export async function parseCaptionsXml(xml) {
     // Public timedtext format
     if (json.transcript && json.transcript.text) {
         const texts = json.transcript.text;
-        return texts.map(node => ({
+        return texts.map((node: any): CaptionEntry => ({
             start: parseFloat(node.$?.start) || 0,
             text: (node._ || '')
                 .trim()

--- a/src/utils/checkModels.ts
+++ b/src/utils/checkModels.ts
@@ -9,5 +9,5 @@ const openai = new OpenAI({
 (async () => {
     const models = await openai.models.list();
     console.log('Доступные модели:');
-    models.data.forEach(m => console.log(m.id));
+    models.data.forEach((m: { id: string }) => console.log(m.id));
 })();

--- a/src/utils/safeJsonParse.ts
+++ b/src/utils/safeJsonParse.ts
@@ -12,7 +12,14 @@
  * @param {boolean} [options.expectArray=false] - if true, extract array `[...]` instead of object `{...}`
  * @returns {any|null} parsed JSON object or null if parsing fails
  */
-export function safeJsonParse(raw, { expectArray = false } = {}) {
+interface SafeParseOptions {
+    expectArray?: boolean;
+}
+
+export function safeJsonParse<T = unknown>(
+    raw: string,
+    { expectArray = false }: SafeParseOptions = {}
+): T | null {
     if (!raw || typeof raw !== "string") return null;
 
     let cleaned = raw.trim();
@@ -29,7 +36,7 @@ export function safeJsonParse(raw, { expectArray = false } = {}) {
     }
 
     try {
-        return JSON.parse(match[0]);
+        return JSON.parse(match[0]) as T;
     } catch (e) {
         console.error("[safeJsonParse] JSON.parse failed:", e, "raw:", cleaned.slice(0, 200));
         return null;

--- a/src/utils/save-summary.ts
+++ b/src/utils/save-summary.ts
@@ -2,12 +2,13 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SummaryBlock } from "../types.ts";
 
 /**
  * Сохраняет массив блоков в формате Markdown в output/summary.md
  * @param {Array<{title: string, summary: string, text: string, tokens: number}>} blocks - массив блоков для сохранения
  */
-export function saveSummary(blocks) {
+export function saveSummary(blocks: SummaryBlock[]): void {
     try {
         const outputDir = path.resolve('output');
         if (!fs.existsSync(outputDir)) {

--- a/src/utils/textChunker.ts
+++ b/src/utils/textChunker.ts
@@ -6,12 +6,23 @@
 
 import { countTokens, encode, decode } from "./tokenCounter.ts";
 
+interface ChunkConfigOptions {
+    defaultChunks?: number;
+    maxConcurrency?: number;
+    defaultOverlap?: number;
+}
+
+interface Chunk {
+    text: string;
+    blockTokens: number;
+}
+
 /**
  * Compute number of chunks, overlap, and total tokens.
  */
 export function computeChunkConfig(
-    text,
-    { defaultChunks = 6, maxConcurrency = 8, defaultOverlap = 0.05 } = {}
+    text: string,
+    { defaultChunks = 6, maxConcurrency = 8, defaultOverlap = 0.05 }: ChunkConfigOptions = {},
 ) {
     const totalTokens = countTokens(text);
     const minChunkSize = 1000;
@@ -33,7 +44,7 @@ export function computeChunkConfig(
 /**
  * Splits text into semantic chunks with logging at each step.
  */
-export function splitByTokenCount(text, options = {}) {
+export function splitByTokenCount(text: string, options: ChunkConfigOptions = {}): Chunk[] {
     const { totalTokens, numberOfChunks, overlapTokens } = computeChunkConfig(text, options);
     console.log(`
 [textChunker] CONFIG → totalTokens=${totalTokens}, numberOfChunks=${numberOfChunks}, overlapTokens=${overlapTokens}`);
@@ -42,7 +53,7 @@ export function splitByTokenCount(text, options = {}) {
     const tokens = encode(text);
     console.log(`[textChunker] Tokens sample: first10=${tokens.slice(0,10)}, last10=${tokens.slice(-10)}`);
 
-    const chunks = [];
+    const chunks: Chunk[] = [];
     let startToken = 0;
     const baseSize = Math.floor((totalTokens + overlapTokens * (numberOfChunks - 1)) / numberOfChunks);
 

--- a/src/utils/tokenCounter.ts
+++ b/src/utils/tokenCounter.ts
@@ -6,7 +6,7 @@
 import { encoding_for_model } from 'tiktoken';
 
 // Model used for token encoding/decoding
-const model = 'gpt-3.5-turbo'; // can be changed to 'gpt-4'
+const model: string = 'gpt-3.5-turbo'; // can be changed to 'gpt-4'
 const encoder = encoding_for_model(model);
 const textDecoder = new TextDecoder('utf-8');
 /**
@@ -14,7 +14,7 @@ const textDecoder = new TextDecoder('utf-8');
  * @param {string} text - Text to analyze
  * @returns {number} - Token count
  */
-export function countTokens(input) {
+export function countTokens(input: string | number[]): number {
     const text = Array.isArray(input)
         ? encoder.decode(input)
         : String(input);
@@ -27,7 +27,7 @@ export function countTokens(input) {
  * @param {number} maxTokens - Maximum allowed tokens
  * @returns {string} - Trimmed text
  */
-export function trimByTokens(text, maxTokens) {
+export function trimByTokens(text: string, maxTokens: number): string {
     const tokens = encoder.encode(text);
     if (tokens.length <= maxTokens) return text;
     const trimmedTokens = tokens.slice(0, maxTokens);
@@ -39,7 +39,7 @@ export function trimByTokens(text, maxTokens) {
  * @param {string} text - Text to encode
  * @returns {number[]} - Array of token IDs
  */
-export function encode(text) {
+export function encode(text: string): number[] {
     return encoder.encode(text);
 }
 
@@ -48,7 +48,7 @@ export function encode(text) {
  * @param {number[]} tokens - Array of token IDs
  * @returns {string} - Decoded text
  */
-export function decode(tokens) {
+export function decode(tokens: number[]): string {
     // tiktoken.decode возвращает Uint8Array → нуждаем в TextDecoder
     const bytes = encoder.decode(tokens);     // Uint8Array
     const text  = textDecoder.decode(bytes);  // string

--- a/src/utils/transcriptPreparer.ts
+++ b/src/utils/transcriptPreparer.ts
@@ -1,13 +1,12 @@
 // utils/transcriptPreparer.js
 
-/**
- * @typedef {Object} TranscriptItem
- * @property {string} text - Текст фразы
- * @property {number} start - Время начала (в секундах)
- * @property {number} [duration] - Длительность (опционально)
- */
+import { countTokens } from "./tokenCounter.ts";
 
-import {countTokens} from "./tokenCounter.ts";
+export interface TranscriptItem {
+    text: string;
+    start: number;
+    duration?: number;
+}
 
 /**
  * Подготавливает транскрипт: очищает текст, объединяет фразы и считает токены.
@@ -17,7 +16,10 @@ import {countTokens} from "./tokenCounter.ts";
  * @param {boolean} [options.removeSpeakers=false] - Удалять ли "Speaker X:" из текста
  * @returns {{ transcript: string, totalTokens: number }} - Объединённый текст и число токенов
  */
-export function prepareTranscript(transcript, { removeSpeakers = false } = {}) {
+export function prepareTranscript(
+    transcript: TranscriptItem[],
+    { removeSpeakers = false }: { removeSpeakers?: boolean } = {}
+): { transcript: string; totalTokens: number } {
     // Шаг 1: очищаем каждую запись
 
     const cleaned = transcript
@@ -50,7 +52,7 @@ export function prepareTranscript(transcript, { removeSpeakers = false } = {}) {
  * @param {boolean} removeSpeakers - Удалять ли Speaker X:
  * @returns {string} - Очищенный текст
  */
-function cleanText(text, removeSpeakers) {
+function cleanText(text: string, removeSpeakers: boolean): string {
     let cleaned = text
         .replace(/\[.*?\]/g, '')                  // удаляем [Music], [Applause] и т.п.
         .replace(/[♪♫]+/g, '')                    // удаляем ♪ и ♫

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -3,7 +3,7 @@
 /**
  * Извлекает videoId из YouTube-ссылки
  */
-export function extractVideoId(url) {
+export function extractVideoId(url: string): string | null {
     const match = url.match(/(?:v=|\/)([0-9A-Za-z_-]{11})/);
     return match ? match[1] : null;
 }
@@ -11,7 +11,7 @@ export function extractVideoId(url) {
 /**
  * Преобразует время в формате 00:00 или 1:02:33 в секунды
  */
-export function timeToSeconds(timeStr) {
+export function timeToSeconds(timeStr: string): number {
     const parts = timeStr.split(':').map(Number);
     if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
     if (parts.length === 2) return parts[0] * 60 + parts[1];


### PR DESCRIPTION
## Summary
- add shared block, boundary pair, and edit interfaces and type openai boundary processing logic
- type safety for JSON parsing, caption parsing, token handling, and other utilities

## Testing
- `npm run build` *(fails: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f9d44050832c8391a1ec54d95ef3