### PR TITLE
feat: add types to utils

### DIFF
--- a/src/utils/boundaryUtils.ts
+++ b/src/utils/boundaryUtils.ts
@@ -3,14 +3,16 @@
 // Pure utility functions for detecting and applying boundary edits
 // ------------------------------------------------------------
 
+import { Block, BoundaryPairWithText, BoundaryEdit } from './boundaryUtils.types.ts';
+
 /**
  * Extract boundary pairs (prev/next blocks) across chunk borders.
- * @param {Array<{id:string,text:string}>} finalBlocks
- * @param {number[]} blocksCountPerChunk
- * @returns {Array<{ prevId:string, currId:string, prevText:string, currText:string }>}
  */
-export function extractBoundaryPairsWithText(finalBlocks: any[], blocksCountPerChunk: string | any[]) {
-    const pairs = [];
+export function extractBoundaryPairsWithText(
+    finalBlocks: Block[],
+    blocksCountPerChunk: number[]
+): BoundaryPairWithText[] {
+    const pairs: BoundaryPairWithText[] = [];
     let offset = 0;
 
     for (let i = 0; i < blocksCountPerChunk.length - 1; i++) {
@@ -35,14 +37,14 @@ export function extractBoundaryPairsWithText(finalBlocks: any[], blocksCountPerC
 
 /**
  * Apply processed edits to finalBlocks array.
- * @param {Array<object>} blocks
- * @param {Array<object>} edits
- * @returns {Array<object>}
  */
-export function applyBoundaryEdits(blocks, edits) {
+export function applyBoundaryEdits<T extends Block>(
+    blocks: T[],
+    edits: BoundaryEdit[]
+): T[] {
     if (!edits || edits.length === 0) return blocks;
 
-    const idToIndex = new Map(blocks.map((b, i) => [b.id, i]));
+    const idToIndex = new Map<string, number>(blocks.map((b, i) => [b.id, i]));
 
     [...edits].reverse().forEach(edit => {
         const iPrev = idToIndex.get(edit.prevId);
@@ -52,7 +54,7 @@ export function applyBoundaryEdits(blocks, edits) {
 
         if (edit.merged) {
             const prevBlock = blocks[iPrev];
-            const mergedBlock = { ...prevBlock, text: edit.merged };
+            const mergedBlock = { ...prevBlock, text: edit.merged } as T;
             blocks.splice(iPrev, 2, mergedBlock);
 
             idToIndex.clear();

--- a/src/utils/boundaryUtils.types.ts
+++ b/src/utils/boundaryUtils.types.ts
@@ -1,0 +1,20 @@
+export interface Block {
+    id: string;
+    text: string;
+    [key: string]: unknown;
+}
+
+export interface BoundaryPairWithText {
+    prevId: string;
+    currId: string;
+    prevText: string;
+    currText: string;
+}
+
+export interface BoundaryEdit {
+    prevId: string;
+    currId: string;
+    merged?: string | null;
+    firstClean?: string | null;
+    secondClean?: string | null;
+}

--- a/src/utils/captionParser.ts
+++ b/src/utils/captionParser.ts
@@ -1,22 +1,20 @@
 
 // utils/captionParser.js
 
-import {parseStringPromise} from 'xml2js';
+import { parseStringPromise } from 'xml2js';
+import { CaptionItem } from './captionParser.types.ts';
 
 /**
  * Парсит XML субтитров YouTube (TTML или публичный timedtext) в массив { start, text }.
  * Поддерживает форматы:
  * - TTML: <tt><body><div><p begin="...">...</p></div></body></tt>
  * - Public timedtext: <transcript><text start="..." dur="...">...</text></transcript>
- *
- * @param {string} xml - сырой XML из captions.download или public timedtext
- * @returns {Promise<Array<{start: number, text: string}>>}
  */
-export async function parseCaptionsXml(xml) {
+export async function parseCaptionsXml(xml: string): Promise<CaptionItem[]> {
     if (!xml || !xml.trim()) {
         throw new Error('Empty XML received — no captions payload');
     }
-    const json = await parseStringPromise(xml);
+    const json: any = await parseStringPromise(xml);
     if (!json) {
         console.error('[parseCaptionsXml] parseStringPromise returned null for XML:', xml.slice(0, 200));
         throw new Error('Failed to parse XML — invalid format');
@@ -25,23 +23,23 @@ export async function parseCaptionsXml(xml) {
     // TTML (Data API)
     console.log("json is - ", json)
     if (json.tt && json.tt.body && json.tt.body[0] && json.tt.body[0].div && json.tt.body[0].div[0]) {
-        const paragraphs = json.tt.body[0].div[0].p || [];
+        const paragraphs: any[] = json.tt.body[0].div[0].p || [];
         return paragraphs.map(node => ({
             start: parseFloat(node.$.begin) || 0,
             text: (node._ || '')
                 .trim()
-                .replace(/\s+/g, ' ')
+                .replace(/\s+/g, ' '),
         }));
     }
 
     // Public timedtext format
     if (json.transcript && json.transcript.text) {
-        const texts = json.transcript.text;
+        const texts: any[] = json.transcript.text;
         return texts.map(node => ({
             start: parseFloat(node.$?.start) || 0,
             text: (node._ || '')
                 .trim()
-                .replace(/\s+/g, ' ')
+                .replace(/\s+/g, ' '),
         }));
     }
 

--- a/src/utils/captionParser.types.ts
+++ b/src/utils/captionParser.types.ts
@@ -1,0 +1,4 @@
+export interface CaptionItem {
+    start: number;
+    text: string;
+}

--- a/src/utils/checkModels.ts
+++ b/src/utils/checkModels.ts
@@ -3,10 +3,10 @@
 import OpenAI from 'openai';
 
 const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY
+    apiKey: process.env.OPENAI_API_KEY as string,
 });
 
-(async () => {
+(async (): Promise<void> => {
     const models = await openai.models.list();
     console.log('Доступные модели:');
     models.data.forEach(m => console.log(m.id));

--- a/src/utils/safeJsonParse.ts
+++ b/src/utils/safeJsonParse.ts
@@ -7,15 +7,14 @@
 
 /**
  * Attempts to safely extract and parse JSON from GPT output.
- * @param {string} raw - raw string from GPT (may contain noise or markdown)
- * @param {object} [options]
- * @param {boolean} [options.expectArray=false] - if true, extract array `[...]` instead of object `{...}`
- * @returns {any|null} parsed JSON object or null if parsing fails
  */
-export function safeJsonParse(raw, { expectArray = false } = {}) {
+export function safeJsonParse<T = unknown>(
+    raw: string,
+    { expectArray = false }: { expectArray?: boolean } = {}
+): T | null {
     if (!raw || typeof raw !== "string") return null;
 
-    let cleaned = raw.trim();
+    let cleaned: string = raw.trim();
 
     // Убираем Markdown-код блоки: ```json ... ```
     cleaned = cleaned.replace(/^\s*```(?:json)?/i, "").replace(/```\s*$/, "").trim();

--- a/src/utils/save-summary.ts
+++ b/src/utils/save-summary.ts
@@ -2,12 +2,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SummaryBlock } from '../types.ts';
 
 /**
  * Сохраняет массив блоков в формате Markdown в output/summary.md
- * @param {Array<{title: string, summary: string, text: string, tokens: number}>} blocks - массив блоков для сохранения
  */
-export function saveSummary(blocks) {
+export function saveSummary(blocks: SummaryBlock[]): void {
     try {
         const outputDir = path.resolve('output');
         if (!fs.existsSync(outputDir)) {
@@ -29,6 +29,10 @@ export function saveSummary(blocks) {
         fs.writeFileSync(outputPath, markdown, 'utf-8');
         console.log(`✅ Saved summary to: ${outputPath}`);
     } catch (error) {
-        console.error('❌ Failed to save summary.md:', error.message);
+        if (error instanceof Error) {
+            console.error('❌ Failed to save summary.md:', error.message);
+        } else {
+            console.error('❌ Failed to save summary.md:', error);
+        }
     }
 }

--- a/src/utils/textChunker.ts
+++ b/src/utils/textChunker.ts
@@ -5,15 +5,16 @@
 // ------------------------------------------------------------
 
 import { countTokens, encode, decode } from "./tokenCounter.ts";
+import { ChunkConfigOptions, ChunkConfig, TextChunk } from './textChunker.types.ts';
 
 /**
  * Compute number of chunks, overlap, and total tokens.
  */
 export function computeChunkConfig(
-    text,
-    { defaultChunks = 6, maxConcurrency = 8, defaultOverlap = 0.05 } = {}
-) {
-    const totalTokens = countTokens(text);
+    text: string,
+    { defaultChunks = 6, maxConcurrency = 8, defaultOverlap = 0.05 }: ChunkConfigOptions = {},
+): ChunkConfig {
+    const totalTokens: number = countTokens(text);
     const minChunkSize = 1000;
     let numberOfChunks = Math.ceil(totalTokens / minChunkSize);
     numberOfChunks = Math.max(1, Math.min(numberOfChunks, maxConcurrency));
@@ -30,19 +31,23 @@ export function computeChunkConfig(
     return { totalTokens, numberOfChunks, overlapTokens, concurrency: numberOfChunks };
 }
 
+
 /**
  * Splits text into semantic chunks with logging at each step.
  */
-export function splitByTokenCount(text, options = {}) {
+export function splitByTokenCount(
+    text: string,
+    options: ChunkConfigOptions = {},
+): TextChunk[] {
     const { totalTokens, numberOfChunks, overlapTokens } = computeChunkConfig(text, options);
     console.log(`
 [textChunker] CONFIG → totalTokens=${totalTokens}, numberOfChunks=${numberOfChunks}, overlapTokens=${overlapTokens}`);
 
     console.log(`[textChunker] Input text snippet: "${text.slice(0,100).replace(/\n/g,' ')}..."`);
-    const tokens = encode(text);
+    const tokens: number[] = encode(text);
     console.log(`[textChunker] Tokens sample: first10=${tokens.slice(0,10)}, last10=${tokens.slice(-10)}`);
 
-    const chunks = [];
+    const chunks: TextChunk[] = [];
     let startToken = 0;
     const baseSize = Math.floor((totalTokens + overlapTokens * (numberOfChunks - 1)) / numberOfChunks);
 
@@ -52,7 +57,7 @@ export function splitByTokenCount(text, options = {}) {
         const sliceCount = sizeTokens + (i > 0 ? overlapTokens : 0);
         console.log(`[textChunker] chunk ${i+1}: startToken=${startToken}, sizeTokens=${sizeTokens}, overlapTokens=${overlapTokens}`);
 
-        const chunkTokens = tokens.slice(startToken, startToken + sliceCount);
+        const chunkTokens: number[] = tokens.slice(startToken, startToken + sliceCount);
         console.log(`[textChunker] raw chunkTokens: first5=${chunkTokens.slice(0,5)}, last5=${chunkTokens.slice(-5)}`);
 
         const chunkTextRaw = decode(chunkTokens);

--- a/src/utils/textChunker.types.ts
+++ b/src/utils/textChunker.types.ts
@@ -1,0 +1,17 @@
+export interface ChunkConfigOptions {
+    defaultChunks?: number;
+    maxConcurrency?: number;
+    defaultOverlap?: number;
+}
+
+export interface ChunkConfig {
+    totalTokens: number;
+    numberOfChunks: number;
+    overlapTokens: number;
+    concurrency: number;
+}
+
+export interface TextChunk {
+    text: string;
+    blockTokens: number;
+}

--- a/src/utils/tokenCounter.ts
+++ b/src/utils/tokenCounter.ts
@@ -6,7 +6,7 @@
 import { encoding_for_model } from 'tiktoken';
 
 // Model used for token encoding/decoding
-const model = 'gpt-3.5-turbo'; // can be changed to 'gpt-4'
+const model: string = 'gpt-3.5-turbo'; // can be changed to 'gpt-4'
 const encoder = encoding_for_model(model);
 const textDecoder = new TextDecoder('utf-8');
 /**
@@ -14,7 +14,7 @@ const textDecoder = new TextDecoder('utf-8');
  * @param {string} text - Text to analyze
  * @returns {number} - Token count
  */
-export function countTokens(input) {
+export function countTokens(input: string | number[]): number {
     const text = Array.isArray(input)
         ? encoder.decode(input)
         : String(input);
@@ -27,7 +27,7 @@ export function countTokens(input) {
  * @param {number} maxTokens - Maximum allowed tokens
  * @returns {string} - Trimmed text
  */
-export function trimByTokens(text, maxTokens) {
+export function trimByTokens(text: string, maxTokens: number): string {
     const tokens = encoder.encode(text);
     if (tokens.length <= maxTokens) return text;
     const trimmedTokens = tokens.slice(0, maxTokens);
@@ -39,7 +39,7 @@ export function trimByTokens(text, maxTokens) {
  * @param {string} text - Text to encode
  * @returns {number[]} - Array of token IDs
  */
-export function encode(text) {
+export function encode(text: string): number[] {
     return encoder.encode(text);
 }
 
@@ -48,9 +48,9 @@ export function encode(text) {
  * @param {number[]} tokens - Array of token IDs
  * @returns {string} - Decoded text
  */
-export function decode(tokens) {
+export function decode(tokens: number[]): string {
     // tiktoken.decode возвращает Uint8Array → нуждаем в TextDecoder
-    const bytes = encoder.decode(tokens);     // Uint8Array
-    const text  = textDecoder.decode(bytes);  // string
+    const bytes = encoder.decode(tokens); // Uint8Array
+    const text = textDecoder.decode(bytes); // string
     return text;
 }

--- a/src/utils/transcriptPreparer.ts
+++ b/src/utils/transcriptPreparer.ts
@@ -1,29 +1,22 @@
 // utils/transcriptPreparer.js
 
-/**
- * @typedef {Object} TranscriptItem
- * @property {string} text - Текст фразы
- * @property {number} start - Время начала (в секундах)
- * @property {number} [duration] - Длительность (опционально)
- */
-
-import {countTokens} from "./tokenCounter.ts";
+import { TranscriptItem } from './transcriptPreparer.types.ts';
+import { countTokens } from "./tokenCounter.ts";
 
 /**
  * Подготавливает транскрипт: очищает текст, объединяет фразы и считает токены.
  *
- * @param {TranscriptItem[]} transcript - Исходный массив субтитров
- * @param {Object} [options={}] - Опции очистки
- * @param {boolean} [options.removeSpeakers=false] - Удалять ли "Speaker X:" из текста
- * @returns {{ transcript: string, totalTokens: number }} - Объединённый текст и число токенов
  */
-export function prepareTranscript(transcript, { removeSpeakers = false } = {}) {
+export function prepareTranscript(
+    transcript: TranscriptItem[],
+    { removeSpeakers = false }: { removeSpeakers?: boolean } = {},
+): { transcript: string; totalTokens: number } {
     // Шаг 1: очищаем каждую запись
 
     const cleaned = transcript
         .map(entry => ({
             ...entry,
-            text: cleanText(entry.text, removeSpeakers)
+            text: cleanText(entry.text, removeSpeakers),
         }))
         .filter(entry => entry.text.trim().length > 0);
 
@@ -50,7 +43,7 @@ export function prepareTranscript(transcript, { removeSpeakers = false } = {}) {
  * @param {boolean} removeSpeakers - Удалять ли Speaker X:
  * @returns {string} - Очищенный текст
  */
-function cleanText(text, removeSpeakers) {
+function cleanText(text: string, removeSpeakers: boolean): string {
     let cleaned = text
         .replace(/\[.*?\]/g, '')                  // удаляем [Music], [Applause] и т.п.
         .replace(/[♪♫]+/g, '')                    // удаляем ♪ и ♫

--- a/src/utils/transcriptPreparer.types.ts
+++ b/src/utils/transcriptPreparer.types.ts
@@ -1,0 +1,5 @@
+export interface TranscriptItem {
+    text: string;
+    start: number;
+    duration?: number;
+}

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -3,7 +3,7 @@
 /**
  * Извлекает videoId из YouTube-ссылки
  */
-export function extractVideoId(url) {
+export function extractVideoId(url: string): string | null {
     const match = url.match(/(?:v=|\/)([0-9A-Za-z_-]{11})/);
     return match ? match[1] : null;
 }
@@ -11,7 +11,7 @@ export function extractVideoId(url) {
 /**
  * Преобразует время в формате 00:00 или 1:02:33 в секунды
  */
-export function timeToSeconds(timeStr) {
+export function timeToSeconds(timeStr: string): number {
     const parts = timeStr.split(':').map(Number);
     if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
     if (parts.length === 2) return parts[0] * 60 + parts[1];


### PR DESCRIPTION
## Summary
- add strict interfaces for boundary editing helpers
- define types for caption parsing, token counting, chunking, transcript prep, and misc utilities
- move interfaces into dedicated `.types.ts` modules and update imports

## Testing
- `npm install -D @types/xml2js` (fails: 403 Forbidden)
- `npm run build` (fails: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set)
- `npx tsc --noEmit` (fails: multiple type errors, e.g., Parameter 'code' implicitly has an 'any' type)
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68a4ff087e1c832c835c357291b7f715